### PR TITLE
Add ZeroNet support

### DIFF
--- a/multicodec/constants.py
+++ b/multicodec/constants.py
@@ -150,6 +150,7 @@ CODECS = {
     'ws':                   {'prefix': 0x01DD, },
     'onion':                {'prefix': 0x01BC, },
     'p2p-circuit':          {'prefix': 0x0122, },
+    'zeronet':              {'prefix': 0x1000, },
 
     # IPLD formats
     'dag-pb':               {'prefix': 0x70, },


### PR DESCRIPTION
Add support for [ZeroNet](https://zeronet.io/) site address. ZeroNet uses old-style Bitcoin addresses as site addresses.

Also see multiformats/multicodec#140.

**Update:** Replaced by #6.