### PR TITLE
WIP: Support private ranges

### DIFF
--- a/multicodec/constants.py
+++ b/multicodec/constants.py
@@ -446,3 +446,4 @@ CODECS = {
 
 NAME_TABLE = {name: value['prefix'] for name, value in CODECS.items()}
 CODE_TABLE = {value['prefix']: name for name, value in CODECS.items()}
+PRIVATE_RANGE = (0x300000, 0x3FFFFF)

--- a/tests/test_multicodec.py
+++ b/tests/test_multicodec.py
@@ -29,6 +29,17 @@ def test_verify_prefix_complete(multicodec, prefix):
     assert extract_prefix(prefixed_data) == prefix_int
 
 
+@pytest.mark.parametrize('multicodec', (0x300000, 0x3FFFFF,))
+def test_verify_private_range_complete(multicodec):
+    data = b'testbytesbuffer'
+    prefix_int = multicodec
+    prefixed_data = add_prefix(multicodec, data)
+
+    assert get_codec(prefixed_data) == multicodec
+    assert remove_prefix(prefixed_data) == data
+    assert extract_prefix(prefixed_data) == prefix_int
+
+
 @pytest.mark.parametrize('multicodec,_', INVALID_CODECS)
 def test_get_prefix_invalid_prefix(multicodec, _):
     with pytest.raises(ValueError) as excinfo:


### PR DESCRIPTION
Added support to work with private ranges. 

It must now support working with private ranges, however, you may still not be able to register private codecs, but it can be verified by using a higher-level abstraction. Possibly, we can add it within the same package as well.