### PR TITLE
docs: trigger Read the Docs build after workflow changes

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,5 @@
 .. include:: ../README.rst
 
-
 Table of contents
 =================
 


### PR DESCRIPTION
## Problem

The previous commit (PR #27) only changed `.github/workflows/` files, which Read the Docs filters out as non-documentation changes. This means Read the Docs didn't trigger a new build after the merge.

## Solution

This PR makes a small formatting change to `docs/index.rst` (removes an extra blank line) to trigger a Read the Docs build. This ensures the documentation is rebuilt and up-to-date.

## Changes

- Minor formatting fix in `docs/index.rst` (removed extra blank line)

This is a minimal change that will trigger the Read the Docs webhook to build the latest documentation.