### PR TITLE
comment out unused html_static_path in docs config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,6 @@ docs-ci:
 	rm -f docs/modules.rst
 	sphinx-apidoc -o docs/ multicodec
 	$(MAKE) -C docs clean
-	mkdir -p docs/_static
 	$(MAKE) -C docs html SPHINXOPTS="-W"
 
 docs: docs-ci

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -146,7 +146,7 @@ html_theme = 'alabaster'
 # here, relative to this directory. They are copied after the builtin
 # static files, so a file named "default.css" will overwrite the builtin
 # "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page
 # bottom, using the given strftime format.


### PR DESCRIPTION
The `docs-ci` target contained creation of the `_static` dir, which allowed CI docs test to pass while ReadTheDocs builds failed because they weren't creating the dir. 

The dir is unused, so commenting out in docs config instead.