### PR TITLE
fix(code): add missing tag categories to _get_tag()

### DIFF
--- a/multicodec/code.py
+++ b/multicodec/code.py
@@ -342,6 +342,14 @@ def _get_tag(code: int) -> str:
     if name in ("multicodec", "multihash", "multiaddr", "multibase", "varsig"):
         return "multiformat"
 
+    # Multikey
+    if name == "chacha20-poly1305":
+        return "multikey"
+
+    # Multisig
+    if "-msig" in name or ("lamport-" in name and "-sig" in name):
+        return "multisig"
+
     # Multihash
     if any(
         h in name
@@ -387,6 +395,10 @@ def _get_tag(code: int) -> str:
     ):
         return "namespace"
 
+    # Nonce
+    if name == "nonce":
+        return "nonce"
+
     # Serialization
     if name in (
         "protobuf",
@@ -401,6 +413,14 @@ def _get_tag(code: int) -> str:
         "ssz",
     ):
         return "serialization"
+
+    # Shelter
+    if name.startswith("shelter-"):
+        return "shelter"
+
+    # Softhash
+    if name == "iscc":
+        return "softhash"
 
     # Transport
     if name in (
@@ -424,6 +444,10 @@ def _get_tag(code: int) -> str:
         "rs256",
     ):
         return "varsig"
+
+    # Vlad
+    if name == "vlad":
+        return "vlad"
 
     # Zeroxcert
     if name in ("zeroxcert-imprint-256",):

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -117,6 +117,32 @@ class CodeTestCase:
         code = Code(0x55)  # raw
         assert code.tag() == "ipld"
 
+        # Multikey
+        code = Code(0xA000)  # chacha20-poly1305
+        assert code.tag() == "multikey"
+
+        # Multisig
+        code = Code(0xD01300)  # es256k-msig
+        assert code.tag() == "multisig"
+        code = Code(0x1A44)  # lamport-sha3-512-sig
+        assert code.tag() == "multisig"
+
+        # Nonce
+        code = Code(0x123B)  # nonce
+        assert code.tag() == "nonce"
+
+        # Shelter
+        code = Code(0x511E00)  # shelter-contract-manifest
+        assert code.tag() == "shelter"
+
+        # Softhash
+        code = Code(0xCC01)  # iscc
+        assert code.tag() == "softhash"
+
+        # Vlad
+        code = Code(0x1207)  # vlad
+        assert code.tag() == "vlad"
+
 
 class ReservedRangeTestCase:
     """Tests for reserved range constants and functions."""


### PR DESCRIPTION
Closes #37.

**What was changed:**
- Added the 6 missing tag categories (`multikey`, `multisig`, `nonce`, `shelter`, `softhash`, `vlad`) to `_get_tag()` in `multicodec/code.py`.
- Reordered the `multisig` block to precede `multihash` to ensure correct tag extraction for overlapping names.
- Added comprehensive unit tests in `tests/test_code.py` to verify each of these new tag categories.

**Why the change was needed:**
- The Go reference implementation supports these tags, but `py-multicodec` was previously categorizing these codecs as `"<unknown>"`. 
- Ensures feature parity and spec compliance within the Python implementation.

**How it was verified:**
- Verified by adding new tag classification tests in `test_code.py` using prefixes like `0xA000`, `0xD01300`, `0x1A44`, `0x123B`, `0x511E00`, `0xCC01`, and `0x1207`.
- Executed `make pr` locally to ensure formatting (ruff), linting (pre-commit), typechecking (mypy), and unit testing (pytest) all pass correctly.